### PR TITLE
move once_cell to dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,7 @@ license = "MIT"
 derive-error = "0"
 native-tls = "0"
 derive_more = "0"
-once_cell = "1"
 log = "0"
+
+[dev-dependencies]
+once_cell = "1"


### PR DESCRIPTION
Hey!

I read over the code in this crate and really like your focus on creating a simple API and nice documentation - great work!

This change is something I stumbled over - you seem to use `once_cell` only in the tests (for the FTP server guard mutex), so it can be moved to `[dev-dependencies]`, then it will only be compiled for tests/examples etc., but not in the actual library. (probably just an oversight anyway ☺️)

Thanks for sharing this. :)